### PR TITLE
修复 ADB 连接失败仍显示成功，并优化连接记录与交互

### DIFF
--- a/service/app/data/api/script/script/executeScript.js
+++ b/service/app/data/api/script/script/executeScript.js
@@ -106,6 +106,39 @@
     return n;
   }
 
+  function isAdbOutputFailure(output) {
+    var text = String(output || "").toLowerCase();
+    if (!text) return true;
+    return /failed to connect|unable to connect|cannot connect|connection refused|积极拒绝|无法连接|error:|failed to pair|pairing failed/.test(
+      text
+    );
+  }
+
+  function isAdbConnectSuccess(output) {
+    var text = String(output || "").toLowerCase();
+    if (!text || isAdbOutputFailure(output)) return false;
+    return /connected to|already connected to/.test(text);
+  }
+
+  function isAdbPairSuccess(output) {
+    var text = String(output || "").toLowerCase();
+    if (!text || isAdbOutputFailure(output)) return false;
+    return /successfully paired/.test(text);
+  }
+
+  function isDeviceListed(devicesOutput, address, port) {
+    var target = address + ":" + port;
+    var lines = String(devicesOutput || "").split(/\r?\n/);
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i].trim();
+      if (!line || line.indexOf("List of devices") === 0) continue;
+      if (line.indexOf(target) !== 0) continue;
+      if (/\boffline\b/i.test(line)) return false;
+      return true;
+    }
+    return false;
+  }
+
   function executeAdbWireless(task, adb, params) {
     var address = normalizeAddress(params.address);
     var connectPort = normalizePort(params.connectPort);
@@ -139,7 +172,7 @@
         ["pair", address + ":" + pairPort, pairCode],
         "pair"
       );
-      if (!pairResult.ok) {
+      if (!pairResult.ok || !isAdbPairSuccess(pairResult.output)) {
         return { ok: false, message: "配对失败" };
       }
     } else {
@@ -152,11 +185,14 @@
       ["connect", address + ":" + connectPort],
       "connect"
     );
-    if (!connectResult.ok) {
+    if (!connectResult.ok || !isAdbConnectSuccess(connectResult.output)) {
       return { ok: false, message: "连接失败" };
     }
 
-    runAdbStep(task, adb, ["devices", "-l"], "devices");
+    var devicesResult = runAdbStep(task, adb, ["devices", "-l"], "devices");
+    if (!isDeviceListed(devicesResult.output, address, connectPort)) {
+      return { ok: false, message: "连接失败：设备未出现在列表中" };
+    }
     return { ok: true, message: "执行完成" };
   }
 

--- a/src/pages/script/LScript.less
+++ b/src/pages/script/LScript.less
@@ -276,9 +276,4 @@
   font-size: 12px;
   color: #666;
   padding: 4px 0;
-  cursor: pointer;
-
-  &:hover {
-    color: #1890ff;
-  }
 }

--- a/src/pages/script/PScript.tsx
+++ b/src/pages/script/PScript.tsx
@@ -399,13 +399,18 @@ const PScript: React.FC = () => {
     </div>
   );
 
-  const renderDeviceField = (device: DeviceProfile, p: ScriptParamDef) => (
+  const renderDeviceField = (
+    device: DeviceProfile,
+    p: ScriptParamDef,
+    options?: { onPressEnter?: () => void }
+  ) => (
     <div key={p.key} className={SelfStyle.paramField}>
       <label className={SelfStyle.paramLabel}>{p.label}</label>
       <Input
         value={(device as unknown as Record<string, string>)[p.key] || ""}
         placeholder={p.placeholder}
         onChange={(e) => patchDevice(device.id, { [p.key]: e.target.value })}
+        onPressEnter={options?.onPressEnter}
         disabled={running}
       />
     </div>
@@ -445,7 +450,7 @@ const PScript: React.FC = () => {
 
       {scriptDevices.map((device) => {
         const expanded = expandedIds.includes(device.id);
-        const deviceExecs = executions.filter((ex) => ex.deviceId === device.id).slice(0, 8);
+        const deviceExecs = executions.filter((ex) => ex.deviceId === device.id).slice(0, 1);
         return (
           <div key={device.id} className={SelfStyle.deviceCard}>
             <div className={SelfStyle.deviceHeader} onClick={() => toggleExpand(device.id)}>
@@ -496,7 +501,11 @@ const PScript: React.FC = () => {
                 <div className={SelfStyle.paramSolo}>
                   {selectedScript.params
                     .filter((p) => p.key === "connectPort")
-                    .map((p) => renderDeviceField(device, p))}
+                    .map((p) =>
+                      renderDeviceField(device, p, {
+                        onPressEnter: () => handleExecuteDevice(device, "connect"),
+                      })
+                    )}
                 </div>
                 <div className={SelfStyle.actionBar}>
                   <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

1. `adb connect` 连接失败（如目标拒绝连接 10061）时，输出面板仍显示「成功」
2. 设备连接历史展示过多条记录
3. 历史记录悬浮时会变色，但无实际交互
4. 连接端口输入框按回车无法触发「直接连接」

## 修复

### 后端 `executeScript.js`
- 新增 `isAdbConnectSuccess` / `isAdbPairSuccess` / `isDeviceListed` 辅助函数
- 解析 `adb connect` / `adb pair` 输出内容判断成败，不再仅依赖 exit code（adb 失败时 exit code 常为 0）
- `adb devices -l` 后校验目标地址是否出现在设备列表中

### 前端 `PScript.tsx`
- 设备连接历史由最多 8 条改为只展示最近 1 条
- 连接端口输入框增加 `onPressEnter`，回车直接触发「直接连接」

### 样式 `LScript.less`
- 移除 `.historyItem` 的 hover 变色与 pointer 光标
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9042ed03-a6ca-4650-9412-56aa990dca2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9042ed03-a6ca-4650-9412-56aa990dca2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

