### PR TITLE
脚本页适配移动端布局

### DIFF
--- a/src/pages/script/LScript.less
+++ b/src/pages/script/LScript.less
@@ -276,4 +276,116 @@
   font-size: 12px;
   color: #666;
   padding: 4px 0;
+  word-break: break-word;
+}
+
+// 移动端：侧栏改顶栏横滑，主区纵向滚动，表单/按钮铺满
+@media screen and (max-width: 768px) {
+  .pageRoot {
+    height: auto;
+    max-height: none;
+    min-height: calc(100vh - 96px);
+    overflow: visible;
+  }
+
+  .main {
+    flex-direction: column;
+    height: auto;
+    min-height: calc(100vh - 96px);
+  }
+
+  .sidebar {
+    width: 100%;
+    min-width: 0;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    border-right: none;
+    border-bottom: 1px solid #f0f0f0;
+  }
+
+  .scriptItem {
+    flex: 0 0 auto;
+    border-bottom: none;
+    white-space: nowrap;
+
+    &.active {
+      border-left: none;
+      border-bottom: 3px solid #1890ff;
+      padding-left: 12px;
+      padding-bottom: 7px;
+    }
+  }
+
+  .content {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .contentHeader {
+    padding: 12px;
+  }
+
+  .formArea {
+    padding: 12px;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .paramGrid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .paramSolo {
+    max-width: none;
+  }
+
+  .addDeviceRow {
+    max-width: none;
+    flex-wrap: wrap;
+
+    :global(.ant-input) {
+      flex: 1 1 140px;
+      min-width: 0;
+    }
+  }
+
+  .deviceBody {
+    padding: 12px;
+  }
+
+  .deviceNameInput {
+    width: 100%;
+    max-width: 220px;
+  }
+
+  .actionBar {
+    flex-wrap: wrap;
+
+    :global(.ant-btn) {
+      flex: 1 1 calc(50% - 4px);
+      min-width: 120px;
+    }
+  }
+
+  .outputPanel {
+    padding: 12px;
+    flex: none;
+  }
+
+  .terminal {
+    min-height: 220px;
+    max-height: 45vh;
+  }
+
+  .historyItem {
+    line-height: 1.5;
+  }
+
+  // 避免 iOS 聚焦输入框时强制放大页面
+  :global(.ant-input) {
+    font-size: 16px;
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更

脚本页移动端适配（`≤768px`）：

- 左侧脚本列表改为顶部横向滚动栏
- 取消固定视口高度，页面可纵向滚动
- 表单参数单列铺满，连接端口/按钮区不再被 `max-width` 卡住
- 操作按钮可换行铺满
- 输出终端保留可用最小高度
- 输入框 16px，减轻 iOS 聚焦放大

桌面布局不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9042ed03-a6ca-4650-9412-56aa990dca2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9042ed03-a6ca-4650-9412-56aa990dca2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

