### PR TITLE
修复迭代页出现两个底部栏

### DIFF
--- a/src/pages/iterative/IterativeTabpane.tsx
+++ b/src/pages/iterative/IterativeTabpane.tsx
@@ -2,7 +2,7 @@ import { PageFooter } from "@/common/components/page";
 import NRouter from "@/../config/router/NRouter";
 import { Button, Space, Table } from "antd";
 import React, { FC, useRef } from "react";
-import { Link, NMDIterative } from "umi";
+import { Link, NMDIterative, history } from "umi";
 import SIterative from "./SIterative";
 import qs from "qs";
 import UCopy from "@/common/utils/UCopy";
@@ -10,8 +10,9 @@ import NIterative from "./NIterative";
 import CreateIterativeModal, {
   ICreateIterativeModal,
 } from "./components/CreateIterativeModal";
-import { CopyOutlined } from "@ant-design/icons";
+import { ArrowLeftOutlined, CopyOutlined } from "@ant-design/icons";
 import AddEnvModal, { IAddEnvModal } from "./components/AddEnvModal";
+import Browser from "@/utils/browser";
 
 import ViewContentModal, {
   IViewContentModal,
@@ -78,9 +79,12 @@ const IterativeTabpane: FC<IIterativeTabpaneProps> = (props) => {
         ></Table>
       </div>
       <PageFooter>
-        <Button onClick={() => onShowCreateIterativeModalModal()}>
-          创建迭代
-        </Button>
+        {!Browser.isMobile() && (
+          <Button icon={<ArrowLeftOutlined />} onClick={() => history.push("/")}>
+            返回
+          </Button>
+        )}
+        <Button onClick={() => onShowCreateIterativeModalModal()}>创建迭代</Button>
         <Button onClick={() => onShowAddEnvModal()}>添加环境</Button>
       </PageFooter>
     </div>

--- a/src/pages/iterative/PIterative.tsx
+++ b/src/pages/iterative/PIterative.tsx
@@ -1,14 +1,11 @@
-import { PageFooter } from "@/common/components/page";
 import NModel from "@/common/namespace/NModel";
-import { Tabs, Button } from "antd";
-import { ArrowLeftOutlined } from "@ant-design/icons";
+import { Tabs } from "antd";
 import React, { useEffect } from "react";
-import { connect, ConnectRC, NMDIterative, history } from "umi";
+import { connect, ConnectRC, NMDIterative } from "umi";
 import SelfStyle from "./LIterative.less";
 import SIterative from "./SIterative";
 import IterativeTabpane from "./IterativeTabpane";
 import RoleTabpane from "./RoleTabPane";
-import Browser from "@/utils/browser";
 
 export interface IIterativeProps {
   MDIterative: NMDIterative.IState;
@@ -34,16 +31,6 @@ const Iterative: ConnectRC<IIterativeProps> = (props) => {
           <RoleTabpane MDIterative={MDIterative}></RoleTabpane>
         </Tabs.TabPane>
       </Tabs>
-      <PageFooter>
-        {!Browser.isMobile() && (
-          <Button
-            icon={<ArrowLeftOutlined />}
-            onClick={() => history.push("/")}
-          >
-            返回
-          </Button>
-        )}
-      </PageFooter>
     </div>
   );
 };

--- a/src/pages/iterative/RoleTabPane.tsx
+++ b/src/pages/iterative/RoleTabPane.tsx
@@ -1,7 +1,9 @@
 import { PageFooter } from "@/common/components/page";
-import { Button, Dropdown, Menu, Space, Table } from "antd";
+import { Button, Dropdown, Space, Table } from "antd";
+import { ArrowLeftOutlined } from "@ant-design/icons";
 import React, { FC, useRef } from "react";
-import { NMDIterative } from "umi";
+import { history, NMDIterative } from "umi";
+import Browser from "@/utils/browser";
 import NIterative from "./NIterative";
 import SIterative from "./SIterative";
 import UCopy from "@/common/utils/UCopy";
@@ -92,6 +94,11 @@ const RoleTabpane: FC<IRoleTabpaneProps> = (props) => {
         ></Table>
       </div>
       <PageFooter>
+        {!Browser.isMobile() && (
+          <Button icon={<ArrowLeftOutlined />} onClick={() => history.push("/")}>
+            返回
+          </Button>
+        )}
         <Dropdown.Button
           placement="top"
           menu={{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

迭代页底部出现两条蓝色操作栏：一条是 Tab 内的「创建迭代 / 添加环境」，另一条是页面级的「返回」。

根因是 `PIterative.tsx` 与 `IterativeTabpane.tsx` 各渲染了一个 `PageFooter`；移动端虽隐藏了「返回」按钮，父级 `PageFooter` 仍会渲染空底栏。

## 修复

- 移除 `PIterative.tsx` 的独立 `PageFooter`
- 将「返回」并入各 Tab 的单一底栏（桌面端显示，移动端隐藏）
- 「角色」Tab 同步处理
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9042ed03-a6ca-4650-9412-56aa990dca2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9042ed03-a6ca-4650-9412-56aa990dca2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

