### PR TITLE
项目管理操作列增加 Git 拉取并显示当前分支

### DIFF
--- a/service/app/data/api/project/project/getGitBranchList.js
+++ b/service/app/data/api/project/project/getGitBranchList.js
@@ -1,0 +1,122 @@
+(function () {
+  var spawnSync = require('child_process').spawnSync;
+  var fs = require('fs');
+
+  function resolveGitBin() {
+    if (process.platform === 'win32') {
+      var candidates = [
+        'C:\\Program Files\\Git\\cmd\\git.exe',
+        'C:\\Program Files (x86)\\Git\\cmd\\git.exe',
+      ];
+      for (var i = 0; i < candidates.length; i++) {
+        if (fs.existsSync(candidates[i])) {
+          return candidates[i];
+        }
+      }
+    }
+    return 'git';
+  }
+
+  var GIT_BIN = resolveGitBin();
+
+  function runGit(cwd, args) {
+    try {
+      var result = spawnSync(GIT_BIN, args, {
+        cwd: cwd,
+        encoding: 'utf-8',
+        timeout: 15000,
+        windowsHide: true,
+        env: Object.assign({}, process.env, {
+          GIT_TERMINAL_PROMPT: '0',
+          GCM_INTERACTIVE: 'Never',
+        }),
+      });
+      var stdout = (result.stdout || '').trim();
+      var stderr = (result.stderr || '').trim();
+      if (result.error) {
+        return {
+          ok: false,
+          stdout: stdout,
+          stderr: stderr,
+          output: (result.error.message || stderr || stdout).trim(),
+        };
+      }
+      return {
+        ok: result.status === 0,
+        stdout: stdout,
+        stderr: stderr,
+        output: (stdout + '\n' + stderr).trim(),
+      };
+    } catch (e) {
+      return {
+        ok: false,
+        stdout: '',
+        stderr: String(e.message || e),
+        output: String(e.message || e),
+      };
+    }
+  }
+
+  function readBranch(cwd) {
+    var branchResult = runGit(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    if (!branchResult.ok) {
+      return { branch: '', error: '无法读取分支' };
+    }
+    return { branch: branchResult.stdout.trim(), error: '' };
+  }
+
+  return function (argData, argParams) {
+    var projectIds = argParams.projectIds;
+    var list = argData.projectList || [];
+
+    if (projectIds && projectIds.length) {
+      var idSet = {};
+      projectIds.forEach(function (id) {
+        idSet[Number(id)] = true;
+      });
+      list = list.filter(function (p) {
+        return idSet[p.id];
+      });
+    }
+
+    var branches = {};
+    list.forEach(function (project) {
+      if (!project || !project.id) return;
+
+      if (!project.rootPath) {
+        branches[project.id] = { isRepo: false, branch: '', error: '' };
+        return;
+      }
+
+      var cwd = project.rootPath;
+      if (!fs.existsSync(cwd)) {
+        branches[project.id] = { isRepo: false, branch: '', error: '路径不存在' };
+        return;
+      }
+
+      var repoCheck = runGit(cwd, ['rev-parse', '--is-inside-work-tree']);
+      if (!repoCheck.ok || repoCheck.stdout !== 'true') {
+        branches[project.id] = { isRepo: false, branch: '', error: '' };
+        return;
+      }
+
+      var branchInfo = readBranch(cwd);
+      branches[project.id] = {
+        isRepo: true,
+        branch: branchInfo.branch,
+        error: branchInfo.error,
+      };
+    });
+
+    return {
+      isWrite: false,
+      response: {
+        code: 200,
+        data: {
+          success: true,
+          branches: branches,
+        },
+      },
+    };
+  };
+})();

--- a/service/app/data/api/project/project/gitExecuteOne.js
+++ b/service/app/data/api/project/project/gitExecuteOne.js
@@ -146,6 +146,11 @@
     return pullOnce(cwd);
   }
 
+  function readCurrentBranch(cwd) {
+    var branchResult = runGit(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    return branchResult.ok ? branchResult.stdout.trim() : '';
+  }
+
   return function (argData, argParams) {
     var startTime = Date.now();
     var steps = [];
@@ -283,6 +288,7 @@
             success: true,
             result: {
               status: 'conflict',
+              branch: readCurrentBranch(cwd),
               message: didStash
                 ? 'pull 冲突，改动已保留在 stash 中，请手动解决'
                 : 'pull 存在合并冲突，请手动解决',
@@ -305,6 +311,7 @@
             success: true,
             result: {
               status: 'failed',
+              branch: readCurrentBranch(cwd),
               message: errMsg,
               errorKind: isAuthError(rawErr) ? 'auth' : isNetworkError(rawErr) ? 'network' : 'other',
               rootPath: cwd,
@@ -315,6 +322,8 @@
         },
       };
     }
+
+    var currentBranch = readCurrentBranch(cwd);
 
     // pull 成功，恢复 stash
     if (didStash) {
@@ -328,6 +337,7 @@
               success: true,
               result: {
                 status: 'conflict',
+                branch: readCurrentBranch(cwd),
                 message: 'pull 成功，但恢复 stash 时冲突，请手动解决',
                 steps: steps,
                 elapsed: Date.now() - startTime,
@@ -344,6 +354,7 @@
             success: true,
             result: {
               status: 'stashed_success',
+              branch: readCurrentBranch(cwd),
               message: '已 stash → pull → 恢复，全部成功',
               steps: steps,
               elapsed: Date.now() - startTime,
@@ -361,6 +372,7 @@
           success: true,
           result: {
             status: 'success',
+            branch: currentBranch,
             message: pullResult.stdout || '拉取成功',
             steps: steps,
             elapsed: Date.now() - startTime,

--- a/src/pages/project/LProject.less
+++ b/src/pages/project/LProject.less
@@ -18,6 +18,28 @@
   }
 }
 
+.gitPullBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding-inline: 4px;
+}
+
+.gitBranch {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #666;
+  font-size: 12px;
+}
+
+@media screen and (max-width: 768px) {
+  .gitBranch {
+    max-width: 72px;
+  }
+}
+
 // 拖拽时禁止选中文字
 :global {
   .row-dragging {

--- a/src/pages/project/PProject.tsx
+++ b/src/pages/project/PProject.tsx
@@ -42,8 +42,14 @@ export interface IProjectProps {
   MDProject: NMDProject.IState;
 }
 
-/** 暂时隐藏项目管理中的 Git 相关入口 */
+/** 暂时隐藏项目管理中的 Git 批量操作入口 */
 const SHOW_GIT_OPERATIONS = false;
+
+type GitBranchInfo = {
+  isRepo: boolean;
+  branch: string;
+  error?: string;
+};
 
 const Project: ConnectRC<IProjectProps> = (props) => {
   const { MDProject } = props;
@@ -52,6 +58,8 @@ const Project: ConnectRC<IProjectProps> = (props) => {
   const [selectedProject, setSelectedProject] = useState<NProject | null>(null);
   const [localIpv4, setLocalIpv4] = useState('');
   const [gitBatchVisible, setGitBatchVisible] = useState(false);
+  const [gitBranchMap, setGitBranchMap] = useState<Record<number, GitBranchInfo>>({});
+  const [gitPullingId, setGitPullingId] = useState<number | null>(null);
   const openingTerminalRef = useRef(false);
 
   useEffect(() => {
@@ -64,6 +72,75 @@ const Project: ConnectRC<IProjectProps> = (props) => {
       }
     });
   }, []);
+
+  async function reqGitBranchList(list?: NProject[]) {
+    const projects = list || MDProject.rsp.list;
+    const ids = projects.filter((p) => p.rootPath && !p.isSfMock).map((p) => p.id!);
+    if (!ids.length) {
+      setGitBranchMap({});
+      return;
+    }
+    const rsp: any = await SProject.getGitBranchList({ projectIds: ids });
+    if (rsp.success && rsp.branches) {
+      setGitBranchMap(rsp.branches);
+    }
+  }
+
+  async function onGitPull(project: NProject) {
+    if (!project.id || gitPullingId) return;
+    setGitPullingId(project.id);
+    try {
+      const rsp: any = await SProject.gitExecuteOne({ projectId: project.id, action: 'pull' });
+      const result = rsp.result;
+      if (!result) {
+        message.error('拉取失败');
+        return;
+      }
+      const status = result.status;
+      if (result.branch) {
+        setGitBranchMap((prev) => ({
+          ...prev,
+          [project.id!]: {
+            ...(prev[project.id!] || { isRepo: true }),
+            isRepo: true,
+            branch: result.branch,
+          },
+        }));
+      }
+      if (status === 'success' || status === 'stashed_success') {
+        message.success(result.message || '拉取成功');
+      } else if (status === 'conflict') {
+        message.warning(result.message || '存在冲突，需手动处理');
+      } else {
+        message.error(result.message || '拉取失败');
+      }
+    } finally {
+      setGitPullingId(null);
+    }
+  }
+
+  function renderGitBlock(project: NProject) {
+    if (!project.rootPath || project.isSfMock) return null;
+    const info = gitBranchMap[project.id!];
+    if (info && !info.isRepo) return null;
+
+    const branch = info?.branch || '…';
+    const loading = gitPullingId === project.id;
+
+    return (
+      <Button
+        type="link"
+        className={SelfStyle.gitPullBtn}
+        loading={loading}
+        onClick={() => onGitPull(project)}
+        title={info?.error}
+      >
+        <BranchesOutlined />
+        <span className={SelfStyle.gitBranch}>{branch}</span>
+        <span>拉取</span>
+      </Button>
+    );
+  }
 
   const DragHandle = SortableHandle(() => (
     <MenuOutlined style={{ cursor: 'grab', color: '#999', userSelect: 'none' }} />
@@ -349,6 +426,8 @@ const Project: ConnectRC<IProjectProps> = (props) => {
             DP
           </Dropdown.Button>
 
+          {renderGitBlock(project)}
+
           {project.name !== 'sf-notes' && (
             <Button
               icon={<SettingOutlined />}
@@ -543,6 +622,7 @@ const Project: ConnectRC<IProjectProps> = (props) => {
           }
         }
       });
+      reqGitBranchList(rsp.list);
     }
   }
   async function reqLocalIpv4() {

--- a/src/pages/project/SProject.tsx
+++ b/src/pages/project/SProject.tsx
@@ -295,6 +295,23 @@ namespace SProject {
     });
   }
 
+  export async function getGitBranchList(data?: {
+    projectIds?: number[];
+  }): Promise<
+    NRsp<{
+      branches: Record<
+        number,
+        { isRepo: boolean; branch: string; error?: string }
+      >;
+    }>
+  > {
+    return request({
+      url: "/project/getGitBranchList",
+      method: "post",
+      data: data || {},
+    });
+  }
+
   export async function gitExecuteOne(data: {
     projectId: number;
     action: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更

项目管理列表「操作」列新增 Git 拉取：

- 展示当前分支名（Git 仓库项目）
- 点击「拉取」执行 `git pull`（有本地改动时自动 stash → pull → pop）
- 拉取后更新分支显示

## 实现

- 后端新增 `getGitBranchList`，批量读取各项目 `git rev-parse --abbrev-ref HEAD`
- `gitExecuteOne` 返回结果附带 `branch` 字段
- 前端在加载项目列表后请求分支信息，操作列渲染分支 + 拉取按钮
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9042ed03-a6ca-4650-9412-56aa990dca2e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9042ed03-a6ca-4650-9412-56aa990dca2e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

